### PR TITLE
アプリサンプルディレクトリを作成する

### DIFF
--- a/example/alcholMeter/css/index.css
+++ b/example/alcholMeter/css/index.css
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+* {
+    -webkit-tap-highlight-color: rgba(0,0,0,0); /* make transparent link selection, adjust last value opacity 0 to 1.0 */
+}
+
+body {
+    -webkit-touch-callout: none;                /* prevent callout to copy image, etc when tap to hold */
+    -webkit-text-size-adjust: none;             /* prevent webkit from resizing text to fit */
+    -webkit-user-select: none;                  /* prevent copy paste, to allow, change 'none' to 'text' */
+    background-color:#E4E4E4;
+    background-image:linear-gradient(top, #A7A7A7 0%, #E4E4E4 51%);
+    background-image:-webkit-linear-gradient(top, #A7A7A7 0%, #E4E4E4 51%);
+    background-image:-ms-linear-gradient(top, #A7A7A7 0%, #E4E4E4 51%);
+    background-image:-webkit-gradient(
+        linear,
+        left top,
+        left bottom,
+        color-stop(0, #A7A7A7),
+        color-stop(0.51, #E4E4E4)
+    );
+    background-attachment:fixed;
+    font-family:'HelveticaNeue-Light', 'HelveticaNeue', Helvetica, Arial, sans-serif;
+    font-size:12px;
+    height:100%;
+    margin:0px;
+    padding:0px;
+    text-transform:uppercase;
+    width:100%;
+}
+
+/* Portrait layout (default) */
+.app {
+    background:url(../img/logo.png) no-repeat center top; /* 170px x 200px */
+    position:absolute;             /* position in the center of the screen */
+    left:50%;
+    top:50%;
+    height:50px;                   /* text area height */
+    width:225px;                   /* text area width */
+    text-align:center;
+    padding:180px 0px 0px 0px;     /* image height is 200px (bottom 20px are overlapped with text) */
+    margin:-115px 0px 0px -112px;  /* offset vertical: half of image height and text area height */
+                                   /* offset horizontal: half of text area width */
+}
+
+/* Landscape layout (with min-width) */
+@media screen and (min-aspect-ratio: 1/1) and (min-width:400px) {
+    .app {
+        background-position:left center;
+        padding:75px 0px 75px 170px;  /* padding-top + padding-bottom + text area = image height */
+        margin:-90px 0px 0px -198px;  /* offset vertical: half of image height */
+                                      /* offset horizontal: half of image width and text area width */
+    }
+}
+
+h1 {
+    font-size:24px;
+    font-weight:normal;
+    margin:0px;
+    overflow:visible;
+    padding:0px;
+    text-align:center;
+}
+
+.event {
+    border-radius:4px;
+    -webkit-border-radius:4px;
+    color:#FFFFFF;
+    font-size:12px;
+    margin:0px 30px;
+    padding:2px 0px;
+}
+
+.event.listening {
+    background-color:#333333;
+    display:block;
+}
+
+.event.received {
+    background-color:#4B946A;
+    display:none;
+}
+
+@keyframes fade {
+    from { opacity: 1.0; }
+    50% { opacity: 0.4; }
+    to { opacity: 1.0; }
+}
+ 
+@-webkit-keyframes fade {
+    from { opacity: 1.0; }
+    50% { opacity: 0.4; }
+    to { opacity: 1.0; }
+}
+ 
+.blink {
+    animation:fade 3000ms infinite;
+    -webkit-animation:fade 3000ms infinite;
+}
+
+div.debug {
+    margin: 30px;
+    font-size: 4em;
+    font-weight: bold;
+}

--- a/example/alcholMeter/index.html
+++ b/example/alcholMeter/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="format-detection" content="telephone=no" />
+        <meta name="msapplication-tap-highlight" content="no" />
+        <!-- WARNING: for iOS 7, remove the width=device-width and height=device-height attributes. See https://issues.apache.org/jira/browse/CB-4323 -->
+        <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height, target-densitydpi=device-dpi" />
+        <link rel="stylesheet" type="text/css" href="css/index.css" />
+        <title>Hello World</title>
+    </head>
+    <body>
+        <div class="app">
+            <h1>Apache Cordova</h1>
+            <div id="deviceready" class="blink">
+                <p class="event listening">Connecting to Device</p>
+                <p class="event received">Device is Ready</p>
+            </div>
+            <div id="debug" class="debug">
+                <span id="alcoholMater">0</span>%
+            </div>
+        </div>
+        <script type="text/javascript" src="cordova.js"></script>
+        <script type="text/javascript" src="pocketduino.js"></script>
+        <script type="text/javascript" src="js/index.js"></script>
+    </body>
+</html>

--- a/example/alcholMeter/js/index.js
+++ b/example/alcholMeter/js/index.js
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+var app = {
+    // Application Constructor
+    initialize: function() {
+        this.bindEvents();
+    },
+    // Bind Event Listeners
+    //
+    // Bind any events that are required on startup. Common events are:
+    // 'load', 'deviceready', 'offline', and 'online'.
+    bindEvents: function() {
+        document.addEventListener('deviceready', this.onDeviceReady, false);
+    },
+    // deviceready Event Handler
+    //
+    // The scope of 'this' is the event. In order to call the 'receivedEvent'
+    // function, we must explicitly call 'app.receivedEvent(...);'
+    onDeviceReady: function() {
+        app.receivedEvent('deviceready');
+    },
+    // Update DOM on a Received Event
+    receivedEvent: function(id) {
+        var parentElement = document.getElementById(id);
+        var listeningElement = parentElement.querySelector('.listening');
+        var receivedElement = parentElement.querySelector('.received');
+
+        listeningElement.setAttribute('style', 'display:none;');
+        receivedElement.setAttribute('style', 'display:block;');
+
+        console.log('Received Event: ' + id);
+
+        /**
+         * アルコール ％のざっくり計算
+         */
+        var getPercentage = function(val) {
+            var min = 450; //だいたいの下限値
+            var max = 850; //だいたいの上限値
+            var ret;
+            if (isNaN(val)) return 0;
+            if (val < min) {
+                ret = 0;
+            } else {
+                ret = Math.floor( (val / max) * 100 );
+                if(ret > 100) ret = 100;
+            }
+            return ret;
+        };
+
+        // HexStringを文字列に変換するメソッド群
+        // TODO: 将来的にはライブラリオプションとして {percer: function(data){} } 辺りを設定すると
+        //       パーサ実行後のデータが振ってくるように修正したい。
+        var hexToByte = function ( s ){
+          return parseInt( s, 16);
+        };
+        var hexStringToByteArray =  function(hexString){
+          if( !hexString ){ return [] }
+          var result = [];
+
+          for (var i = 0; i < hexString.length; i+=2) {
+            result.push(hexToByte(hexString.substr(i,2)));
+          }
+          return result;
+        };
+        var decodeHexString = function( hexString ){
+          return hexStringToByteArray( hexString )
+            .map( function( code){ return String.fromCharCode( code ) })
+            .join("");
+        };
+
+        // 読みとった文字列データより、アルコール度数データをピックアップする
+        var pickUpAlcoholData = function( data ){
+          // TODO : s to \r プロトコル判定メソッドのparcer化(前述)
+          var decodeS0DData = function( str ){
+            return str.substring( str.indexOf("s") + 1 , str.indexOf("\r"));
+          };
+          // TODO :NaNのハンドリング
+          return parseInt( decodeS0DData( data ) );
+        };
+
+        // PocketDuino データ受信リスナ
+        var elAlcoholMeter = document.getElementById('alcoholMater');
+        pocketduino.on('data', function(e) {
+            var decodedData = decodeHexString( e.data );
+            console.log(e.data);
+            elAlcoholMeter.innerHTML = getPercentage( pickUpAlcoholData( decodedData ) );
+        });
+        // PocketDuino アタッチリスナ
+        pocketduino.on('attached', function() {
+            pocketduino.run('AlcoholSensor.hex');
+        });
+        // PocketDuino デタッチリスナ
+        pocketduino.on('detached', function() {
+            elAlcoholMeter.innerHTML = "0";
+            pocketduino.stop();
+        });
+        pocketduino.deviceListener();
+        pocketduino.run('AlcoholSensor.hex');
+
+    },
+    onPause: function() {
+        document.getElementById('alcoholMater').innerHTML = "0";
+        pocketduino.setInfo("!!! Paused !!!");
+        pocketduino.stop();
+    },
+    onResume: function() {
+        pocketduino.setInfo("!!! Resumed !!!");
+        pocketduino.run('AlcoholSensor.hex');
+    }
+};
+
+app.initialize();

--- a/src/android/PocketDuino.java
+++ b/src/android/PocketDuino.java
@@ -114,6 +114,9 @@ public class PocketDuino extends CordovaPlugin {
         } else if (action.equals("closeDevice")) {
             closeDevice(callbackContext);
             return true;    // exec()はtrueを返さないと successCallbackの後にerrorCallbackが走ってしまう
+        } else if( action.equals("write")) {
+            writeSerial(callbackContext, args);
+            return true;    // exec()はtrueを返さないと successCallbackの後にerrorCallbackが走ってしまう
         } else {
             PluginResult dataResult = new PluginResult(PluginResult.Status.INVALID_ACTION, "Invalid Action");
             callbackContext.sendPluginResult(dataResult);
@@ -223,6 +226,32 @@ public class PocketDuino extends CordovaPlugin {
             dataResult.setKeepCallback(true);
             callbackContext.sendPluginResult(dataResult);
         }
+    }
+
+    /**
+     *
+     */
+    private void writeSerial(CallbackContext callbackContext, JSONArray args ){
+      try{
+        String command = args.getString(0);
+        byte[] buf = command.getBytes();
+        Log.d(POCKETDUINO, command);
+        this.mPhysicaloid.write( buf , buf.length );
+        PluginResult dataResult = new PluginResult(PluginResult.Status.OK);
+        dataResult.setKeepCallback(true);
+        callbackContext.sendPluginResult(dataResult);
+      }catch( Exception e ){
+        try{
+          String json = "{\"message\":" + e.toString() + " }";
+          JSONObject parameter = new JSONObject(json);
+          PluginResult dataResult = new PluginResult(PluginResult.Status.ERROR, parameter);
+          dataResult.setKeepCallback(true);
+          callbackContext.sendPluginResult(dataResult);
+          String hoge;
+        }catch(Exception ex){
+          Log.e(POCKETDUINO, ex.toString());
+        }
+      }
     }
 
     /**

--- a/www/pocketduino.js
+++ b/www/pocketduino.js
@@ -130,6 +130,12 @@ PocketDuino.prototype.loadHexFile = function(fileName, successCallback, errorCal
 };
 
 /**
+ * PocketDuino シリアル書き込み
+ */
+PocketDuino.prototype.write = function( command, successCallback, errorCallback ){
+  cordova.exec( successCallback, errorCallback, "PocketDuino", "write", [command]);
+
+/**
 * PocketDuino デバイスオープンから受信までのラッパー
 */
 PocketDuino.prototype.run = function(fileName, successCallback, errorCallback) {


### PR DESCRIPTION
このexampleディレクトリの中にWebアプリサンプルの完成形を入れていくアイデアです。
いろんなセンサ用のhexといっしょにサンプルアプリも増やしていけたらいいなと。

`$cordova add cordova-plugin-pocketduino` 実行後に `./plugins/com.physicaroid.pocketduino.cordova/` 下にexampleディレクトリがコピーされます。ここから `www` 下に htmlやjsをコピペして `$cordova run android` するとすぐアプリが使える。という流れにしたい。

本当は `$cordova add cordova-plugin-pocketduino` 後に `www` 下に exampleがコピーされるようにしたかったんだけど [plugin.xmlの要素](http://docs.phonegap.com/en/edge/guide_plugins_plugin_spec.md.html) をみるかぎりそういうことはできないみたい。asset要素とかsource-file要素とか使ってみたけど `platform` 下にしかコピーされなかったので無理みたい。
